### PR TITLE
bump to 1.0.8 and update dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @fhoehle @mitchellwood @whophil
+* @0xbe7a @fhoehle @mitchellwood @whophil

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,22 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
-!/*/
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -54,12 +54,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About dash-extensions-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/dash-extensions-feedstock/blob/main/LICENSE.txt)
 
-Home: https://github.com/thedirtyfew/dash-extensions/
+Home: https://dash-extensions.com
 
 Package license: MIT
 
@@ -143,6 +143,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@0xbe7a](https://github.com/0xbe7a/)
 * [@fhoehle](https://github.com/fhoehle/)
 * [@mitchellwood](https://github.com/mitchellwood/)
 * [@whophil](https://github.com/whophil/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - flask-caching =2.0.2
     - jsbeautifier >=1.14.3,<2
     - more-itertools >=9.0.0,<10.0.0
-    - dataclass-wizard >=0.22.2,<0.23.0
+    - dataclass-wizard >=0.22.0,<0.23.0
   run_constrained:
     - dash-mantine-components >=0.11.1,<0.12.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dash-extensions" %}
-{% set version = "1.0.7" %}
+{% set version = "1.0.8" %}
 
 
 package:
@@ -8,25 +8,28 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dash_extensions-{{ version }}.tar.gz
-  sha256: 46c4ec7c7d3b42db63032005f7d258435bc0092d0fec6f6ce000be68befeb102
+  sha256: a461bdc3b3c300cdb525cb264b201691d086b7e19355db8b458bf9e23dbda259
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8,<4.0
     - pip
     - poetry-core >=1
 
   run:
-    - python >=3.7
-    - dash >=2.7
-    - flask-caching =2.0.1
+    - python >=3.8,<4.0
+    - dash >=2.9.3
+    - flask-caching =2.0.2
     - jsbeautifier >=1.14.3,<2
-    - more-itertools >=8.12.0,<9
+    - more-itertools >=9.0.0,<10.0.0
+    - dataclass-wizard >=0.22.2,<0.23.0
+  run_constrained:
+    - dash-mantine-components >=0.11.1,<0.12.0
 
 
 test:
@@ -39,7 +42,7 @@ test:
   #   - pip
 
 about:
-  home: https://github.com/thedirtyfew/dash-extensions/
+  home: https://dash-extensions.com
   summary: Extensions for Plotly Dash.
   license: MIT
   license_file: LICENSE
@@ -49,3 +52,4 @@ extra:
     - whophil
     - mitchellwood
     - fhoehle
+    - '0xbe7a'


### PR DESCRIPTION
- bump to 1.0.8 and update deps
- MNT: Re-rendered with conda-build 3.28.2, conda-smithy 3.30.4, and conda-forge-pinning 2024.01.26.06.19.12

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
